### PR TITLE
Enhance risk dashboard interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
-# survey
-Draft risk survey
+# Risk preference hazard prioritiser
+
+This prototype lets stakeholders express their risk priorities and immediately
+see how the weighting changes the order of key hazards.
+
+## Getting started
+
+There are two quick ways to view the prototype:
+
+1. **Double-click `index.html`.** Because all assets are local or loaded from a
+   CDN, opening the file directly in your browser works for simple
+   experimentation.
+2. **Serve the folder locally** if you prefer a `http://` URL (for example,
+   some browsers block certain features on `file://` pages):
+
+   ```bash
+   cd /path/to/survey
+   python3 -m http.server 8000
+   ```
+
+   Then visit <http://localhost:8000/> and the app will load automatically.
+
+## How it works
+
+* Adjust the three sliders to express how much you want to emphasise safety,
+  financial, and environmental considerations. A panel next to the controls
+  shows the normalised weighting applied in the scoring model.
+* Use **Balance weights** to quickly equalise the sliders or **Reset to
+  defaults** to return to the initial emphasis profile.
+* The app normalises your inputs into weights and combines them with the
+  illustrative hazard data in `app.js` to create a composite score. The
+  "Current top priority" callout highlights the leading hazard and the driver
+  behind its score.
+* The bar chart and ranked list update in real time to highlight the hazards
+  that best match the selected preferences. Each hazard card shows a breakdown
+  of how each dimension contributes to the priority score.
+
+To customise the tool, edit `app.js` to add new hazards, change the weighting
+formula, or connect it to your own data source.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# survey
+Draft risk survey

--- a/app.js
+++ b/app.js
@@ -1,0 +1,345 @@
+const hazards = [
+  {
+    name: 'Severe weather',
+    description: 'Storms and flooding that disrupt operations and compromise safety.',
+    likelihood: 0.7,
+    severity: 0.8,
+    metrics: {
+      safety: 0.65,
+      financial: 0.6,
+      environmental: 0.7,
+    },
+  },
+  {
+    name: 'Cyber attack',
+    description: 'Targeted intrusion leading to data loss and downtime.',
+    likelihood: 0.55,
+    severity: 0.85,
+    metrics: {
+      safety: 0.35,
+      financial: 0.9,
+      environmental: 0.2,
+    },
+  },
+  {
+    name: 'Wildfire',
+    description: 'Fast-moving fires damaging facilities and ecosystems.',
+    likelihood: 0.35,
+    severity: 0.95,
+    metrics: {
+      safety: 0.85,
+      financial: 0.7,
+      environmental: 0.95,
+    },
+  },
+  {
+    name: 'Supply chain failure',
+    description: 'Critical supplier outage causing extended service delays.',
+    likelihood: 0.5,
+    severity: 0.7,
+    metrics: {
+      safety: 0.45,
+      financial: 0.8,
+      environmental: 0.3,
+    },
+  },
+  {
+    name: 'Chemical spill',
+    description: 'Release of hazardous substances affecting people and surroundings.',
+    likelihood: 0.25,
+    severity: 0.9,
+    metrics: {
+      safety: 0.9,
+      financial: 0.65,
+      environmental: 0.85,
+    },
+  },
+];
+
+const dimensionLabels = {
+  safety: 'Safety & wellbeing',
+  financial: 'Financial stability',
+  environmental: 'Environmental impact',
+};
+
+const sliders = Array.from(
+  document.querySelectorAll('#preferences-form input[type="range"]')
+);
+const outputs = new Map();
+sliders.forEach((slider) => {
+  const output = slider.parentElement.querySelector('output');
+  outputs.set(slider.name, output);
+});
+
+const summaryOutputs = new Map(
+  Array.from(document.querySelectorAll('[data-dimension]')).map((element) => [
+    element.dataset.dimension,
+    element,
+  ])
+);
+
+const hazardChartCtx = document.getElementById('hazard-chart');
+let hazardChart;
+
+const hazardTable = document.querySelector('.hazard-table');
+const topHazardName = document.querySelector('[data-top-hazard-name]');
+const topHazardScore = document.querySelector('[data-top-hazard-score]');
+const topHazardReason = document.querySelector('[data-top-hazard-reason]');
+
+const DEFAULT_WEIGHTS = sliders.reduce((acc, slider) => {
+  acc[slider.name] = Number(slider.value);
+  return acc;
+}, {});
+
+function normaliseWeights(weights) {
+  const total = Object.values(weights).reduce((sum, value) => sum + value, 0);
+  if (total === 0) {
+    const even = 1 / Object.keys(weights).length;
+    return Object.fromEntries(
+      Object.keys(weights).map((key) => [key, even])
+    );
+  }
+
+  return Object.fromEntries(
+    Object.entries(weights).map(([key, value]) => [key, value / total])
+  );
+}
+
+function calculateScores(weights) {
+  const normalised = normaliseWeights(weights);
+
+  const scored = hazards
+    .map((hazard) => {
+      const contributions = Object.fromEntries(
+        Object.entries(normalised).map(([key, weight]) => {
+          const impact = hazard.metrics[key];
+          const weighted = impact * weight;
+          return [key, { weight, impact, weighted }];
+        })
+      );
+
+      const preferenceFactor = Object.values(contributions).reduce(
+        (total, { weighted }) => total + weighted,
+        0
+      );
+
+      const baseRisk = hazard.likelihood * 0.4 + hazard.severity * 0.6;
+      const score = baseRisk * (0.4 + 0.6 * preferenceFactor);
+
+      return {
+        ...hazard,
+        preferenceFactor,
+        baseRisk,
+        score,
+        contributions,
+      };
+    })
+    .sort((a, b) => b.score - a.score);
+
+  return { normalised, scored };
+}
+
+function renderChart(data) {
+  const labels = data.map((hazard) => hazard.name);
+  const scores = data.map((hazard) => Number(hazard.score.toFixed(3)));
+
+  const dataset = {
+    label: 'Priority score',
+    data: scores,
+    borderRadius: 18,
+    backgroundColor: 'rgba(37, 99, 235, 0.65)',
+    hoverBackgroundColor: 'rgba(37, 99, 235, 0.85)',
+    borderSkipped: false,
+  };
+
+  if (!hazardChart) {
+    hazardChart = new Chart(hazardChartCtx, {
+      type: 'bar',
+      data: {
+        labels,
+        datasets: [dataset],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+          y: {
+            beginAtZero: true,
+            max: 1.2,
+            ticks: {
+              callback: (value) => value.toFixed(1),
+            },
+            title: {
+              display: true,
+              text: 'Composite risk score',
+            },
+          },
+        },
+        plugins: {
+          legend: {
+            display: false,
+          },
+          tooltip: {
+            callbacks: {
+              label: (context) => {
+                const hazard = data[context.dataIndex];
+                const priority = context.formattedValue;
+                return [
+                  `Priority score: ${priority}`,
+                  `Likelihood: ${(hazard.likelihood * 100).toFixed(0)}%`,
+                  `Severity: ${(hazard.severity * 100).toFixed(0)}%`,
+                ];
+              },
+            },
+          },
+        },
+      },
+    });
+  } else {
+    hazardChart.data.labels = labels;
+    hazardChart.data.datasets[0] = dataset;
+    hazardChart.update();
+  }
+}
+
+function renderTable(data, normalised) {
+  hazardTable.innerHTML = '';
+  hazardTable.dataset.weights = JSON.stringify(normalised);
+
+  data.forEach((hazard, index) => {
+    const card = document.createElement('article');
+    card.className = 'hazard-card';
+    const breakdownItems = Object.entries(hazard.contributions)
+      .map(([key, details]) => {
+        const label = dimensionLabels[key];
+        const weightPercent = (details.weight * 100).toFixed(0);
+        const impactPercent = (details.impact * 100).toFixed(0);
+        const weightedPercent = (details.weighted * 100).toFixed(0);
+
+        return `
+          <li>
+            <span>${label}</span>
+            <span>${weightPercent}% × ${impactPercent}% = <strong>${weightedPercent}%</strong></span>
+          </li>
+        `;
+      })
+      .join('');
+
+    card.innerHTML = `
+      <h3>${index + 1}. ${hazard.name}</h3>
+      <p>${hazard.description}</p>
+      <div class="hazard-meta">
+        <span>Priority score: ${hazard.score.toFixed(2)}</span>
+        <span>Likelihood: ${(hazard.likelihood * 100).toFixed(0)}%</span>
+        <span>Severity: ${(hazard.severity * 100).toFixed(0)}%</span>
+      </div>
+      <ul class="hazard-breakdown">${breakdownItems}</ul>
+    `;
+    hazardTable.appendChild(card);
+  });
+}
+
+function updateOutputs(weights, normalised) {
+  sliders.forEach((slider) => {
+    const value = Number(slider.value);
+    const output = outputs.get(slider.name);
+    output.textContent = `${(value * 10).toFixed(0)}%`;
+  });
+
+  summaryOutputs.forEach((element, key) => {
+    const percent = normalised[key] * 100;
+    element.textContent = `${percent.toFixed(0)}%`;
+  });
+}
+
+function collectWeights() {
+  return sliders.reduce((acc, slider) => {
+    acc[slider.name] = Number(slider.value);
+    return acc;
+  }, {});
+}
+
+function update() {
+  const weights = collectWeights();
+  const { normalised, scored } = calculateScores(weights);
+  updateOutputs(weights, normalised);
+  renderChart(scored);
+  renderTable(scored, normalised);
+  updateTopHazard(scored);
+}
+
+function updateTopHazard(data) {
+  if (!topHazardName || !topHazardScore || !topHazardReason) {
+    return;
+  }
+
+  const [first] = data;
+
+  if (!first) {
+    topHazardName.textContent = 'No hazards available';
+    topHazardScore.textContent = '';
+    topHazardReason.textContent = '';
+    return;
+  }
+
+  topHazardName.textContent = first.name;
+  topHazardScore.textContent = `Score ${first.score.toFixed(2)}`;
+
+  const primaryContribution = Object.entries(first.contributions).reduce(
+    (best, entry) => {
+      if (!best || entry[1].weighted > best[1].weighted) {
+        return entry;
+      }
+      return best;
+    },
+    null
+  );
+
+  if (!primaryContribution) {
+    topHazardReason.textContent = '';
+    return;
+  }
+
+  const [dimension, details] = primaryContribution;
+  topHazardReason.textContent = `${dimensionLabels[dimension]} is contributing the most (${(
+    details.weighted * 100
+  ).toFixed(0)}% of the preference factor).`;
+}
+
+sliders.forEach((slider) => {
+  slider.addEventListener('input', update, { passive: true });
+});
+
+const balanceButton = document.getElementById('balance-weights');
+const resetButton = document.getElementById('reset-weights');
+
+function setWeights(newWeights) {
+  sliders.forEach((slider) => {
+    if (newWeights[slider.name] !== undefined) {
+      slider.value = newWeights[slider.name];
+    }
+  });
+  update();
+}
+
+balanceButton?.addEventListener('click', () => {
+  const weights = collectWeights();
+  const sum = Object.values(weights).reduce((total, value) => total + value, 0);
+  const average = Math.round(sum / sliders.length);
+  const balanced = sliders.reduce((acc, slider) => {
+    acc[slider.name] = Math.min(
+      Number(slider.max),
+      Math.max(Number(slider.min), average)
+    );
+    return acc;
+  }, {});
+  setWeights(balanced);
+});
+
+resetButton?.addEventListener('click', () => {
+  setWeights(DEFAULT_WEIGHTS);
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+  update();
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Risk Preference Hazard Prioritiser</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" defer></script>
+    <script src="app.js" type="module" defer></script>
+  </head>
+  <body>
+    <header class="page-header">
+      <h1>Risk Preference Hazard Prioritiser</h1>
+      <p>
+        Adjust the sliders to reflect how strongly you want to prioritise each
+        dimension of risk. The chart will reorder the hazards in real time based
+        on your preferences.
+      </p>
+    </header>
+
+    <main class="layout">
+      <section class="controls" aria-labelledby="preferences-heading">
+        <h2 id="preferences-heading">Your risk preferences</h2>
+        <form id="preferences-form">
+          <div class="control">
+            <label for="safety">Safety &amp; wellbeing</label>
+            <input
+              type="range"
+              id="safety"
+              name="safety"
+              min="0"
+              max="10"
+              step="1"
+              value="7"
+            />
+            <output for="safety" data-unit="%"></output>
+            <p class="control-hint">
+              Higher values mean you want to focus on hazards that threaten
+              people and operations.
+            </p>
+          </div>
+          <div class="control">
+            <label for="financial">Financial stability</label>
+            <input
+              type="range"
+              id="financial"
+              name="financial"
+              min="0"
+              max="10"
+              step="1"
+              value="5"
+            />
+            <output for="financial" data-unit="%"></output>
+            <p class="control-hint">
+              Higher values emphasise hazards that can cause direct monetary
+              loss or business disruption.
+            </p>
+          </div>
+          <div class="control">
+            <label for="environmental">Environmental impact</label>
+            <input
+              type="range"
+              id="environmental"
+              name="environmental"
+              min="0"
+              max="10"
+              step="1"
+              value="6"
+            />
+            <output for="environmental" data-unit="%"></output>
+            <p class="control-hint">
+              Higher values prioritise hazards that damage the environment or
+              community assets.
+            </p>
+          </div>
+          <div class="weights-panel" aria-live="polite">
+            <h3>Normalised emphasis</h3>
+            <p class="weights-panel-hint">
+              These percentages show how the sliders combine into weights for
+              the scoring formula.
+            </p>
+            <dl class="weights-breakdown">
+              <div>
+                <dt>Safety &amp; wellbeing</dt>
+                <dd data-dimension="safety">0%</dd>
+              </div>
+              <div>
+                <dt>Financial stability</dt>
+                <dd data-dimension="financial">0%</dd>
+              </div>
+              <div>
+                <dt>Environmental impact</dt>
+                <dd data-dimension="environmental">0%</dd>
+              </div>
+            </dl>
+          </div>
+          <div class="form-actions">
+            <button type="button" id="balance-weights" class="button ghost">
+              Balance weights
+            </button>
+            <button type="button" id="reset-weights" class="button">
+              Reset to defaults
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section class="chart-section" aria-labelledby="chart-heading">
+        <h2 id="chart-heading">Prioritised hazards</h2>
+        <canvas id="hazard-chart" role="img" aria-label="Hazard priority bar chart"></canvas>
+        <p class="chart-description">
+          Scores combine inherent hazard severity with your preference weights.
+          Hover over a bar to see the underlying data.
+        </p>
+        <aside class="top-hazard" aria-live="polite">
+          <h3>Current top priority</h3>
+          <p class="top-hazard-overview">
+            <span data-top-hazard-name>Loading…</span>
+            <span class="top-hazard-score" data-top-hazard-score></span>
+          </p>
+          <p class="top-hazard-metrics" data-top-hazard-reason></p>
+        </aside>
+        <div class="hazard-table" aria-live="polite"></div>
+      </section>
+    </main>
+
+    <footer class="page-footer">
+      <p>
+        This prototype uses illustrative hazard data. Adjust the formula in
+        <code>app.js</code> to reflect your organisation's risk model.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,294 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  line-height: 1.5;
+  --bg: #f6f7fb;
+  --surface: #ffffff;
+  --text-primary: #1f2933;
+  --text-secondary: #52606d;
+  --accent: #2563eb;
+  --accent-light: rgba(37, 99, 235, 0.12);
+  --border: rgba(15, 23, 42, 0.08);
+  --shadow: 0 14px 35px rgba(15, 23, 42, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text-primary);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 2.5rem clamp(1.5rem, 5vw, 4rem);
+}
+
+.page-header,
+.page-footer {
+  max-width: 70rem;
+  margin: 0 auto;
+  text-align: center;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.page-header h1 {
+  font-size: clamp(2rem, 5vw, 2.8rem);
+  font-weight: 700;
+}
+
+.page-header p,
+.page-footer p {
+  color: var(--text-secondary);
+  font-size: 1rem;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+  gap: 2rem;
+  max-width: 70rem;
+  margin: 0 auto;
+  width: 100%;
+}
+
+section {
+  background: var(--surface);
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  box-shadow: var(--shadow);
+}
+
+.controls {
+  display: grid;
+  gap: 1.5rem;
+  align-content: start;
+}
+
+.controls h2,
+.chart-section h2 {
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.control {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.control label {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.control input[type='range'] {
+  accent-color: var(--accent);
+  width: 100%;
+  cursor: pointer;
+}
+
+.control output {
+  justify-self: end;
+  font-weight: 600;
+  color: var(--accent);
+  background: var(--accent-light);
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  font-variant-numeric: tabular-nums;
+}
+
+.control-hint {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.weights-panel {
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+  display: grid;
+  gap: 0.75rem;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), transparent);
+}
+
+.weights-panel h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.weights-panel-hint {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.weights-breakdown {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.weights-breakdown div {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  font-size: 0.9rem;
+}
+
+.weights-breakdown dt {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.weights-breakdown dd {
+  color: var(--accent);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 1.25rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: var(--accent);
+  color: white;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+  box-shadow: 0 10px 18px rgba(37, 99, 235, 0.25);
+}
+
+.button:hover,
+.button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 28px rgba(37, 99, 235, 0.35);
+}
+
+.button:focus-visible {
+  outline: 2px solid rgba(37, 99, 235, 0.6);
+  outline-offset: 2px;
+}
+
+.button.ghost {
+  background: transparent;
+  color: var(--accent);
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.4);
+}
+
+.button.ghost:hover,
+.button.ghost:focus-visible {
+  background: rgba(37, 99, 235, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.6);
+}
+
+.chart-section {
+  display: grid;
+  gap: 1.5rem;
+  align-content: start;
+}
+
+.chart-description {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  text-align: center;
+}
+
+.top-hazard {
+  border: 1px dashed rgba(37, 99, 235, 0.4);
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+  display: grid;
+  gap: 0.4rem;
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.top-hazard h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.top-hazard-overview {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  font-weight: 600;
+}
+
+.top-hazard-score {
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+}
+
+.top-hazard-metrics {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.hazard-table {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.hazard-card {
+  border: 1px solid var(--border);
+  border-radius: 0.9rem;
+  padding: 0.85rem 1.1rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.hazard-card h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.hazard-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.hazard-breakdown {
+  list-style: none;
+  display: grid;
+  gap: 0.35rem;
+  margin-top: 0.5rem;
+}
+
+.hazard-breakdown li {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.hazard-breakdown li span:first-child {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: 1.5rem;
+  }
+
+  section {
+    padding: 1.25rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a normalised weighting panel with balance/reset controls and a top-priority callout
- compute detailed contribution breakdowns in the scoring logic and surface them in the hazard cards
- expand styling and documentation to reflect the richer interactions

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e4255ea2b08320865f0bbf67073209